### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 A MCP server project that creates powerpoint presentations
 
+<a href="https://glama.ai/mcp/servers/h1wl85c8gs">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/h1wl85c8gs/badge" alt="Powerpoint Server MCP server" />
+</a>
+
 ## Components
 
 ### Tools
@@ -38,10 +42,6 @@ The server implements multiple tools:
 - ```generate-and-save-image```: Generates an image for the presentation using a FLUX model
   - Takes "prompt" and "file_name" as required string arguments
   - Creates an image using the free FLUX model on TogetherAI (requires an API key)
-
-
-
-
 
 ## Configuration
 
@@ -91,7 +91,6 @@ On Windows: `%APPDATA%/Claude/claude_desktop_config.json`
 - ```--directory```: the path where you cloned the repo above
 - ```--folder-path```: the path where powerpoint decks and images will be saved to. Also the path where you should place any images you want the MCP server to use.
 
-
 ```
   # Add the server to your claude_desktop_config.json
   "mcpServers": {
@@ -127,7 +126,6 @@ Assuming you have SQLite MCP Server installed.
 Review 2024 Sales Data table. Create a presentation showing current trends, use tables and charts as appropriate
 
 ```
-
 
 # License
 


### PR DESCRIPTION
This PR adds a badge for the [Powerpoint MCP Server](https://glama.ai/mcp/servers/h1wl85c8gs) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/h1wl85c8gs">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/h1wl85c8gs/badge" alt="Powerpoint Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.